### PR TITLE
Ajustes nos estilos do cadastro e login

### DIFF
--- a/pages/public/login.vue
+++ b/pages/public/login.vue
@@ -18,6 +18,8 @@
           <v-form ref="form" v-model="status" lazy-validation>
             <v-col cols="12">
               <v-text-field
+                dark
+                color="#fff"
                 v-model="email"
                 :rules="emailRules"
                 label="Email"
@@ -25,6 +27,8 @@
                 required
               ></v-text-field>
               <v-text-field
+                dark
+                color="#fff"
                 v-model="password"
                 :rules="passwordRules"
                 label="Senha"
@@ -149,15 +153,12 @@ export default {
 };
 </script>
 
-<style>
-
-.theme--light.v-icon {
-  color: #d6adff;
-}
+<style scoped>
 ::placeholder {
   color: #aa56ff !important;
 }
-.bg { 
+
+.bg {
   width: 100%;
   height: 100%;
   position: fixed;
@@ -165,26 +166,33 @@ export default {
   background-size: cover;
   background-position: center;
 }
-.v-dialog {
+
+::v-deep .v-dialog {
   background: #fff;
   text-align: center;
 }
+
 .v-card__title {
   justify-content: center;
 }
+
 .v-form {
   width: 100%;
 }
+
 .v-input__slot:before,
 .v-input__slot::before {
   border-color: #c58aff !important;
 }
+
 .v-text-field > .v-input__control > .v-input__slot:after {
   border-color: #fff !important;
 }
+
 .v-label {
   color: #c58aff !important;
 }
+
 .primary--text {
   color: #c58aff !important;
   caret-color: #c58aff !important;
@@ -199,9 +207,11 @@ export default {
   animation: intro 300ms backwards;
   animation-delay: 350ms;
 }
+
 .layout {
   background: #6600cc !important;
 }
+
 .bg-symbol {
   display: flex;
   -webkit-box-pack: center;
@@ -235,5 +245,11 @@ export default {
   color: #c58aff;
 }
 
+::v-deep .v-dialog {
+  background-color: #FFF;
+}
 
+::v-deep .v-card__title+.v-card__text {
+  text-align: center;
+}
 </style>

--- a/pages/public/signup.vue
+++ b/pages/public/signup.vue
@@ -274,29 +274,29 @@ export default {
 }
 
 /* inputs */
-::v-deep .v-text-field {
+::v-deep .theme--light.v-text-field {
   margin-top: 0;
 }
 
-::v-deep .v-input:not(.v-input--is-disabled) input {
+
+::v-deep .theme--light.v-input:not(.v-input--is-disabled) input {
   font-size: 12px;
   color: #60c;
 }
 
-::v-deep .v-text-field:not(.v-input--has-state) > .v-input__control > .v-input__slot:hover:before {
+::v-deep .theme--light.v-text-field:not(.v-input--has-state)>.v-input__control>.v-input__slot:hover:before {
   border-color: #60c;
 }
 
-::v-deep .v-label,
-::v-deep .v-icon,
-::v-deep .v-btn__content {
+::v-deep .theme--light.v-label,
+::v-deep .theme--light.v-icon {
   font-size: 12px;
   font-weight: 600;
   line-height: 15px;
   color: #aa56ff;
 }
 
-::v-deep .v-icon {
+::v-deep .theme--light.v-icon {
   font-size: 20px;
 }
 
@@ -306,62 +306,29 @@ export default {
 
 ::v-deep .v-btn__content {
   color: #fff;
+  font-size: 12px;
   font-weight: 900;
+  line-height: 15px;
 }
 
-::v-deep .v-text-field > .v-input__control > .v-input__slot::before {
+::v-deep .theme--light.v-text-field > .v-input__control > .v-input__slot::before {
   border-color: #aa56ff;
 }
 
-::v-deep .v-input--has-state > .v-input__control > .v-input__slot::before {
+
+::v-deep .v-text-field.v-input--has-state>.v-input__control>.v-input__slot:before {
   border-color: #ff5252; /* cor da borda quando der estado de erro */
 }
 
-/* .v-form {
-  width: 100%;
+::v-deep .v-messages__message {
+  color: #ff5252;
+  font-size: 12px;
+  margin-left: 5px;
 }
-
-
-
-.theme--light.v-text-field > .v-input__control > .v-input__slot:before {
-  border-color: #aa56ff !important;
-}
-
-.theme--light.v-text-field:not(.v-input--has-state) > .v-input__control > .v-input__slot:hover:before {
-  border-color: #6600CC !important;
-}
-
-.theme--light.v-input:not(.v-input--is-disabled) input {
-  color: #6600CC !important;
-}
-
-.v-input__slot {
-  margin-top: 20px !important;
-  padding-left: 5px !important;
-  width: 100%;
-  border-radius: unset !important;
-  background-color: #fff !important;
-  box-shadow: none !important;
-}
-
-.v-text-field {
-  padding-top: 0 !important;
-  margin-top: 0 !important;
-  color: #6600CC;
-}
-
-.theme--dark.v-input:not(.v-input--is-disabled) input {
-  color: #6600CC;
-}
-
-.v-icon.v-icon.v-icon--link {
-  color: #aa56ff;
-  padding-right: 5px;
-}
-*/
 
 .login-link {
-  color: #6600cc !important;
+  font-size: 12px;
+  color: #6600cc;
 }
 
 .hide-form {
@@ -370,19 +337,5 @@ export default {
 
 .error-form {
   animation: nono 300ms, intro paused;
-}
-
-
-/* Error messages */
-.v-messages__message {
-  color: #ff5252 !important;
-  font-size: 12px !important;
-  margin-left: 5px;
-}
-
-
-/* Snackbar */
-.v-snack__content {
-  border-radius: 5px;
 }
 </style>

--- a/pages/public/signup.vue
+++ b/pages/public/signup.vue
@@ -19,15 +19,17 @@
           </v-col>
         </v-row>
         <v-row>
-          <v-form ref="form" v-model="status" lazy-validation>
-            <v-col cols="12">
+          <v-col cols="12">
+            <v-form ref="form" v-model="status" lazy-validation>
               <v-text-field
+                color="#60c"
                 v-model="form.name"
                 label="Nome *"
                 name="name"
                 required
               ></v-text-field>
               <v-text-field
+                color="#60c"
                 v-model="form.email"
                 :rules="emailRules"
                 label="Email *"
@@ -35,42 +37,51 @@
                 required
               ></v-text-field>
               <v-text-field
+                color="#60c"
                 v-model="form.password"
                 label="Senha *"
                 name="password"
                 :rules="passwordRules"
                 :type="showPass ? 'password' : 'text'"
-                :append-icon="showPass ? 'mdi-eye' : 'mdi-eye-off'"
+                :append-icon="showPass ? 'mdi-eye-off' : 'mdi-eye'"
                 @click:append="() => (showPass = !showPass)"
                 required
               ></v-text-field>
               <v-text-field
+                color="#60c"
                 v-model="form.confirmPassword"
                 label="Confirmar senha *"
                 :rules="confirmPasswordRules"
                 :type="showConfirmPass ? 'password' : 'text'"
-                :append-icon="showConfirmPass ? 'mdi-eye' : 'mdi-eye-off'"
+                :append-icon="showConfirmPass ? 'mdi-eye-off' : 'mdi-eye'"
                 @click:append="() => (showConfirmPass = !showConfirmPass)"
                 required
               ></v-text-field>
               <v-text-field
+                color="#60c"
                 v-model="form.urlFacebook"
                 label="URL do Facebook"
                 name="urlFacebook"
                 required
               ></v-text-field>
               <v-text-field
+                color="#60c"
                 type="text"
                 v-model="form.urlInstagram"
                 label="URL do Instagram"
                 name="urlInstagram"
                 required
               ></v-text-field>
-            </v-col>
-            <v-col cols="12">
-              <v-btn class="btn-block btn-submit" depressed large @click="submit">Cadastrar</v-btn>
-            </v-col>
-          </v-form>
+              <v-btn
+                color="#60c"
+                dark
+                block
+                depressed
+                large
+                @click="submit"
+              >Cadastrar</v-btn>
+            </v-form>
+          </v-col>
           <v-col cols="12" class="text-center">
             <a class="login-link" @click="gotoLogin">Ops, já tenho conta</a>
           </v-col>
@@ -100,7 +111,7 @@
 {
   path : '/cadastro'
 }
-  
+
 </router>
 
 <script scoped>
@@ -144,12 +155,12 @@ export default {
         this.animateForm(true);
         auth
           .signUp(this.form, this.token)
-          .then(res => {     
-            this.loading = false;  
+          .then(res => {
+            this.loading = false;
             this.confirmSnackbar('Cadastro efetuado! ;)', 'success');
             setTimeout(() => {
               this.gotoLogin();
-            }, 2500); 
+            }, 2500);
           })
           .catch(err => {
             this.confirmSnackbar('Ocorreu um erro.', 'error');
@@ -199,11 +210,11 @@ export default {
   },
 
   mounted() {
-    auth.getExternalCredentials().then(res => {      
+    auth.getExternalCredentials().then(res => {
         const { data } = res;
-        this.token = data.accessToken;   
+        this.token = data.accessToken;
       })
-      .catch(err => {            
+      .catch(err => {
         console.error(err);
       });
   },
@@ -241,8 +252,9 @@ export default {
 
 /* Page */
 .page-title {
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 900;
+  line-height: 24px;
   text-transform: uppercase;
   color: #6600cc;
 }
@@ -258,19 +270,58 @@ export default {
 }
 
 .logo-container img {
-  width: 80px;
+  width: 48px;
 }
 
+/* inputs */
+::v-deep .v-text-field {
+  margin-top: 0;
+}
 
-/* Form */
-.v-form {
+::v-deep .v-input:not(.v-input--is-disabled) input {
+  font-size: 12px;
+  color: #60c;
+}
+
+::v-deep .v-text-field:not(.v-input--has-state) > .v-input__control > .v-input__slot:hover:before {
+  border-color: #60c;
+}
+
+::v-deep .v-label,
+::v-deep .v-icon,
+::v-deep .v-btn__content {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 15px;
+  color: #aa56ff;
+}
+
+::v-deep .v-icon {
+  font-size: 20px;
+}
+
+::v-deep .v-btn {
+  margin-top: 15px;
+}
+
+::v-deep .v-btn__content {
+  color: #fff;
+  font-weight: 900;
+}
+
+::v-deep .v-text-field > .v-input__control > .v-input__slot::before {
+  border-color: #aa56ff;
+}
+
+::v-deep .v-input--has-state > .v-input__control > .v-input__slot::before {
+  border-color: #ff5252; /* cor da borda quando der estado de erro */
+}
+
+/* .v-form {
   width: 100%;
 }
 
-.theme--light.v-label {
-  font-weight: 600;
-  color: #aa56ff !important;
-}
+
 
 .theme--light.v-text-field > .v-input__control > .v-input__slot:before {
   border-color: #aa56ff !important;
@@ -307,13 +358,7 @@ export default {
   color: #aa56ff;
   padding-right: 5px;
 }
-
-.theme--light.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined) {
-  background: #6600cc !important;
-  border-radius: 5px !important;
-  color: #fff !important;
-  font-weight: bold !important;
-}
+*/
 
 .login-link {
   color: #6600cc !important;


### PR DESCRIPTION
Adicionei `scoped` aos estilos do Login, o que ocasionou uma leve alteradas nos estilos, que eu já arrumei.

Fiz ajustes em toda página de cadastro para ficar fiel ao design no Figma, fiz o teste da página em produção e ela está funcionando perfeitamente (pelo menos na minha máquina :p).

Com essa adição do `scoped`, também foi corrigido o bug de voltar a página no modo history e os estilos serem trocados.