### PR TITLE
Mudança no endpoint e no objeto mandado no corpo da requisiçao de cadastro de usuário

### DIFF
--- a/pages/public/signup.vue
+++ b/pages/public/signup.vue
@@ -129,9 +129,9 @@ export default {
         password: '',
         confirmPassword: '',
         urlFacebook: '',
-        urlInstagram: '',
-        role: 'STUDENT',
+        urlInstagram: ''
       },
+
       nameRules: [v => !!v || 'Digite seu nome'],
       passwordRules: [
         v => !!v || 'Digite a senha',
@@ -147,9 +147,11 @@ export default {
   methods: {
     submit() {
       if (this.$refs.form.validate()) {
+        const postObject = Object.assign({}, this.form)
+        delete postObject.confirmPassword
         this.animateForm(true)
         auth
-          .signUp(this.form, this.token)
+          .signUp(postObject, this.token)
           .then(res => {
             this.loading = false
             this.confirmSnackbar('Cadastro efetuado! ;)', 'success')

--- a/services/http/auth.js
+++ b/services/http/auth.js
@@ -84,7 +84,7 @@ export default {
   },
 
   signUp: (form, token) => {
-    return http.post('api/v1/user', form, {
+    return http.post('api/v1/user/student', form, {
       headers: { Authorization: `Bearer ${token}` },
     })
   },


### PR DESCRIPTION
Como não passamos mais a Role do User no cadastro de estudante, foi necessário mudar a url e adequar o objeto de requisição.

- Endpoint da chamada no front mudado de '/api/v1/user' para '/api/v1/user/student';
- Remoção das propriedades "role" e "confirm-password", do objeto passado no corpo de requisição, para se adequar ao DTO disponibilizado no swagger;
