### PR TITLE
(1.13) Componente Home; E correção de :key id no SideMenu

### DIFF
--- a/components/CourseCard.vue
+++ b/components/CourseCard.vue
@@ -4,6 +4,7 @@
     elevation="0"
     color="transparent"
     :tile="true"
+    :to="'/curso/' + slug"
   >
     <v-img
       :src="image"
@@ -17,7 +18,7 @@
 <script>
 export default {
   name: 'courseCard',
-  props: ['title', 'image', 'teacher']
+  props: ['title', 'image', 'teacher', 'slug']
 }
 </script>
 

--- a/components/CourseCard.vue
+++ b/components/CourseCard.vue
@@ -1,5 +1,6 @@
 <template>
   <v-card
+    class="v-card-body"
     elevation="0"
     color="transparent"
     :tile="true"
@@ -24,6 +25,10 @@ export default {
 </script>
 
 <style>
+.v-card-body {
+  padding: 0 0 16px 34px;
+}
+
 .v-card__title{
   font-weight: 500;
   font-size: 12px;

--- a/components/CourseCard.vue
+++ b/components/CourseCard.vue
@@ -4,11 +4,8 @@
     elevation="0"
     color="transparent"
     :tile="true"
-    width="280"
   >
     <v-img
-      aspect-ratio="1"
-      height="150px"
       :src="image"
     >
     </v-img>
@@ -24,24 +21,105 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+.v-responsive.v-image {
+ padding-top: 75%;
+ height: 0;
+ position: relative;
+ width: 100%;
+}
+
+.v-responsive__sizer {
+  padding: 0;
+}
+
+.v-image__image {
+ background: url("http://i.imgur.com/SrPdUD4.png") 50% 50% no-repeat;
+ background-color: #000;
+ position: absolute;
+ width: 100%;
+ height: 100%;
+}
+
+@media screen and (orientation: landscape) {
+  .v-image__image {
+    background: url("http://i.imgur.com/SrPdUD4.png") no-repeat;
+    position: absolute;
+    width: 300px;
+    height: 200px;
+  }
+
+  .v-card-body {
+    margin-right: 2.5em;
+  }
+
+  .v-card-body div {
+    cursor: pointer;
+  }
+
+  .v-responsive.v-image {
+    height: 200px;
+    width: 300px;
+  }
+
+  @media (min-width: 48em) {
+    .v-card-body {
+      margin-right: 0;
+      padding-right: 1em;
+      width: 50%;
+    }
+
+    .v-responsive.v-image {
+      height: 250px;
+      width: 350px;
+    }
+
+    .v-image__image {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  @media (min-width: 64em) {
+    .v-card-body {
+      width: 33.33333%;
+      padding-right: 3em;
+    }
+  }
+
+  @media (min-width: 80em) {
+    .v-responsive.v-image {
+      height: 400px;
+      width: 600px;
+    }
+  }
+}
+
+@media screen and (min-width: 27.5em) and (orientation: portrait) {
+  .v-card-body {
+    width: 50%;
+    padding-right: 1em;
+  }
+}
+
 .v-card-body {
-  padding: 0 0 16px 34px;
+  margin-bottom: 1.5em;
+  align-self: stretch;
 }
 
 .v-card__title{
   font-weight: 500;
-  font-size: 12px;
+  font-size: 1em;
+  padding: 5px 0 0;
+  line-height: 0.8em;
   color: #1A1A1A;
-  padding:5px 0 0;
-  line-height: 15px;
 }
 
 .theme--light.v-card .v-card__subtitle{
   padding: 0;
-  color: #1A1A1A;
+  color: #1a1a1a;
   font-weight: 300;
-  font-size: 10px;
+  font-size: 0.7em;
   line-height: 12px;
 }
 </style>

--- a/components/CourseCard.vue
+++ b/components/CourseCard.vue
@@ -82,15 +82,15 @@ export default {
 
   @media (min-width: 64em) {
     .v-card-body {
-      width: 33.33333%;
+      width: 25%;
       padding-right: 3em;
     }
   }
 
-  @media (min-width: 80em) {
-    .v-responsive.v-image {
-      height: 400px;
-      width: 600px;
+  @media (min-width: 100em) {
+    .v-card-body {
+      width: 20%;
+      padding-right: 3em;
     }
   }
 }

--- a/components/SideMenu.vue
+++ b/components/SideMenu.vue
@@ -54,28 +54,28 @@ export default {
         link: "/aluno/perfil"
       },
       {
-        id: 1,
+        id: 2,
         label: "Meus Cursos",
         icon: "mdi-library",
         link: "/aluno/meus-cursos"
       },
       {
-        id: 2,
+        id: 3,
         label: "Meus Certificados",
         icon: "mdi-school",
         link: "/aluno/certificados"
       },
       {
-        id: 3,
+        id: 4,
         label: "Contribua",
         icon: "mdi-source-fork",
         link: "/contribua"
       },
-      { id: 4, label: "Sobre", icon: "mdi-file-document-box", link: "/sobre" },
-      { id: 5, label: "Ajuda", icon: "mdi-help-circle", link: "/ajuda" },
-      { id: 6, label: "Contato", icon: "mdi-cellphone", link: "/contato" },
-      { id: 7, label: "Imprensa", icon: "mdi-camcorder", link: "/imprensa" },
-      { id: 8, label: "Investidores", icon: "mdi-coin", link: "/investidores" }
+      { id: 5, label: "Sobre", icon: "mdi-file-document-box", link: "/sobre" },
+      { id: 6, label: "Ajuda", icon: "mdi-help-circle", link: "/ajuda" },
+      { id: 7, label: "Contato", icon: "mdi-cellphone", link: "/contato" },
+      { id: 8, label: "Imprensa", icon: "mdi-camcorder", link: "/imprensa" },
+      { id: 9, label: "Investidores", icon: "mdi-coin", link: "/investidores" }
     ]
   }),
   methods: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,7 +21,7 @@ export default {
   },
 
   env: {
-    baseUrl: process.env.VUE_APP_BASE_URL || 'http://localhost:8080/',
+    baseUrl: process.env.VUE_APP_BASE_URL || 'https://newschoolbrapi-dev.herokuapp.com/',
     credentials:{
       name: process.env.VUE_APP_CLIENT_CREDENTIAL_NAME || 'NEWSCHOOL@FRONT',
       secret: process.env.VUE_APP_CLIENT_CREDENTIAL_SECRET || 'NEWSCHOOL@FRONTSECRET',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,7 +21,7 @@ export default {
   },
 
   env: {
-    baseUrl: process.env.VUE_APP_BASE_URL || 'https://newschoolbrapi-dev.herokuapp.com/',
+    baseUrl: process.env.VUE_APP_BASE_URL || 'http://localhost:8080/',
     credentials:{
       name: process.env.VUE_APP_CLIENT_CREDENTIAL_NAME || 'NEWSCHOOL@FRONT',
       secret: process.env.VUE_APP_CLIENT_CREDENTIAL_SECRET || 'NEWSCHOOL@FRONTSECRET',

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -89,7 +89,6 @@ export default {
     return courses.getAll().then(response =>
       store.commit('courses/set', response.data)
     )
-    return Promise.resolve(coursesPromise)
   }
 
 

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -52,7 +52,6 @@ export default {
     loadUserName() {
       let storedUser = JSON.parse(localStorage.getItem("user"))
       if (storedUser) {
-        this.user = storedUser;
         this.user.name = storedUser.name.split(' ')[0]
       }
     }

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -83,7 +83,7 @@ export default {
     }
   },
   mounted() {
-    this.getUser();
+    this.loadUserName();
   },
   asyncData({ store, data, params, $axios }) {
     const coursesPromise = courses.getAll().then(response =>

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -39,10 +39,26 @@ export default {
     CourseCard
   },
   data: () => ({
+    title: 'Bem-vindo',
     user: {
       name: ''
     }
   }),
+  head() {
+    return {
+      title: this.title,
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content:
+            'Seja bem vindo(a) ao aplicativo da New School - Levamos educação de qualidade ' +
+            'na linguagem da quebrada para as periferias do Brasil, através da tecnologia e da ' + 
+            'curadoria de conteúdos baseados nas habilidades do futuro.',
+        },
+      ],
+    }
+  },
   computed: {
     courses() {
       return this.$store.state.courses.list

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -13,6 +13,7 @@
         :title="course.title"
         :teacher="course.authorId"
         :image="course.thumbUrl"
+        :slug="course.slug"
       />
     </article>
     <client-only>
@@ -20,31 +21,6 @@
     </client-only>
   </main>
 </template>
-
-<!--<template>
-  <main class="max-content">
-      <header class="welcome">
-        <h1 class="welcome-title">Olá joão</h1>
-        <h2 class="welcome-subtitle">Seja bem vindo</h2>
-      </header>
-
-      <article :key="category.name" v-for="category in categoryCourses">
-        <h3 class="title-section">{{category.name}}</h3>
-        <horizontal-scroll :horizontalPadding="34" :gap="20">
-          <course-card
-            v-for="course in category.courses"
-            :key="course.id"
-            :title="course.name"
-            :teacher="course.teacher"
-            :image="course.image"
-          />
-        </horizontal-scroll>
-      </article>
-    <client-only>
-      <navigation-bar />
-    </client-only>
-  </main>
-</template>-->
 
 <router>
   {
@@ -54,7 +30,6 @@
 
 <script>
 import NavigationBar from "~/components/NavigationBar.vue";
-// import HorizontalScroll from "~/components/HorizontalScroll.vue";
 import CourseCard from "~/components/CourseCard";
 import courses from '~/services/http/courses';
 
@@ -90,80 +65,6 @@ export default {
       store.commit('courses/set', response.data)
     )
   }
-
-
-  // data: () => ({
-  //   categoryCourses:[{
-  //     name: "Cursos",
-  //     courses:[
-  //       {
-  //         id:1,
-  //         name: "Curso 1",
-  //         teacher: "Gustavo Raña",
-  //         image: "http://i.imgur.com/SrPdUD4.png"
-  //       },
-  //       {
-  //         id:2,
-  //         name: "Curso 2",
-  //         teacher: "Mateus Vinicius",
-  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-  //       },
-  //       {
-  //         id:3,
-  //         name: "Curso 3",
-  //         teacher: "Patricia Camarões",
-  //         image: "http://i.imgur.com/SrPdUD4.png"
-  //       },
-  //     ]
-  //   },
-  //   {
-  //     name: "Cursos top",
-  //     courses:[
-  //       {
-  //         id:4,
-  //         name: "Curso 1",
-  //         teacher: "Gustavo Raña",
-  //         image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
-  //       },
-  //       {
-  //         id:5,
-  //         name: "Curso 2",
-  //         teacher: "Mateus Vinicius",
-  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-  //       },
-  //       {
-  //         id:6,
-  //         name: "Curso 3",
-  //         teacher: "Patricia Camarões",
-  //         image: "http://i.imgur.com/SrPdUD4.png"
-  //       },
-  //     ]
-  //   },
-  //   {
-  //     name: "Cursos mais vistos",
-  //     courses:[
-  //       {
-  //         id:7,
-  //         name: "Curso 1",
-  //         teacher: "Gustavo Raña",
-  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-  //       },
-  //       {
-  //         id:8,
-  //         name: "Curso 2",
-  //         teacher: "Mateus Vinicius",
-  //         image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
-  //       },
-  //       {
-  //         id:9,
-  //         name: "Curso 3",
-  //         teacher: "Patricia Camarões",
-  //         image: "http://i.imgur.com/SrPdUD4.png"
-  //       },
-  //     ]
-  //   },
-  //   ]
-  // }),
 };
 </script>
 
@@ -255,5 +156,4 @@ export default {
   padding: 1.25em 0 0.5em 1.5em;
   text-transform: uppercase;
 }
-
 </style>

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -1,5 +1,28 @@
 <template>
   <main class="max-content">
+    <header class="welcome">
+      <h1 class="welcome-title">{{'Olá ' + user.name}}</h1>
+      <h2 class="welcome-subtitle">Seja bem vindo</h2>
+    </header>
+
+    <article>
+      <h3 class="titleSection">CURSOS</h3>
+      <course-card
+        :key="course.id"
+        v-for="course in courses"
+        :title="course.title"
+        :teacher="course.authorId"
+        :image="course.thumbUrl"
+      />
+    </article>
+    <client-only>
+      <navigation-bar />
+    </client-only>
+  </main>
+</template>
+
+<!--<template>
+  <main class="max-content">
       <header class="welcome">
         <h1 class="welcome-title">Olá joão</h1>
         <h2 class="welcome-subtitle">Seja bem vindo</h2>
@@ -21,7 +44,7 @@
       <navigation-bar />
     </client-only>
   </main>
-</template>
+</template>-->
 
 <router>
   {
@@ -31,97 +54,129 @@
 
 <script>
 import NavigationBar from "~/components/NavigationBar.vue";
-import HorizontalScroll from "~/components/HorizontalScroll.vue";
+// import HorizontalScroll from "~/components/HorizontalScroll.vue";
 import CourseCard from "~/components/CourseCard";
+import courses from '~/services/http/courses';
 
 export default {
-  data: () => ({
-    categoryCourses:[{
-      name: "Cursos",
-      courses:[
-        {
-          id:1,
-          name: "Curso 1",
-          teacher: "Gustavo Raña",
-          image: "http://i.imgur.com/SrPdUD4.png"
-        },
-        {
-          id:2,
-          name: "Curso 2",
-          teacher: "Mateus Vinicius",
-          image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-        },
-        {
-          id:3,
-          name: "Curso 3",
-          teacher: "Patricia Camarões",
-          image: "http://i.imgur.com/SrPdUD4.png"
-        },
-      ]
-    },
-    {
-      name: "Cursos top",
-      courses:[
-        {
-          id:4,
-          name: "Curso 1",
-          teacher: "Gustavo Raña",
-          image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
-        },
-        {
-          id:5,
-          name: "Curso 2",
-          teacher: "Mateus Vinicius",
-          image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-        },
-        {
-          id:6,
-          name: "Curso 3",
-          teacher: "Patricia Camarões",
-          image: "http://i.imgur.com/SrPdUD4.png"
-        },
-      ]
-    },
-    {
-      name: "Cursos mais vistos",
-      courses:[
-        {
-          id:7,
-          name: "Curso 1",
-          teacher: "Gustavo Raña",
-          image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
-        },
-        {
-          id:8,
-          name: "Curso 2",
-          teacher: "Mateus Vinicius",
-          image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
-        },
-        {
-          id:9,
-          name: "Curso 3",
-          teacher: "Patricia Camarões",
-          image: "http://i.imgur.com/SrPdUD4.png"
-        },
-      ]
-    },
-    ]
-  }),
   components: {
     NavigationBar,
-    HorizontalScroll,
     CourseCard
+  },
+  data: () => ({
+    user: {
+      name: ''
+    }
+  }),
+  computed: {
+    courses() {
+      return this.$store.state.courses.list
+    }
+  },
+  methods: {
+    getUser() {
+      let storedUser = JSON.parse(localStorage.getItem("user"))
+      if (storedUser) {
+        this.user = storedUser;
+        this.user.name = this.user.name.split(' ')[0]
+      }
+    }
+  },
+  mounted() {
+    this.getUser();
+  },
+  asyncData({ store, data, params, $axios }) {
+    const coursesPromise = courses.getAll().then(response =>
+      store.commit('courses/set', response.data)
+    )
+    return Promise.resolve(coursesPromise)
   }
+
+
+  // data: () => ({
+  //   categoryCourses:[{
+  //     name: "Cursos",
+  //     courses:[
+  //       {
+  //         id:1,
+  //         name: "Curso 1",
+  //         teacher: "Gustavo Raña",
+  //         image: "http://i.imgur.com/SrPdUD4.png"
+  //       },
+  //       {
+  //         id:2,
+  //         name: "Curso 2",
+  //         teacher: "Mateus Vinicius",
+  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
+  //       },
+  //       {
+  //         id:3,
+  //         name: "Curso 3",
+  //         teacher: "Patricia Camarões",
+  //         image: "http://i.imgur.com/SrPdUD4.png"
+  //       },
+  //     ]
+  //   },
+  //   {
+  //     name: "Cursos top",
+  //     courses:[
+  //       {
+  //         id:4,
+  //         name: "Curso 1",
+  //         teacher: "Gustavo Raña",
+  //         image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
+  //       },
+  //       {
+  //         id:5,
+  //         name: "Curso 2",
+  //         teacher: "Mateus Vinicius",
+  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
+  //       },
+  //       {
+  //         id:6,
+  //         name: "Curso 3",
+  //         teacher: "Patricia Camarões",
+  //         image: "http://i.imgur.com/SrPdUD4.png"
+  //       },
+  //     ]
+  //   },
+  //   {
+  //     name: "Cursos mais vistos",
+  //     courses:[
+  //       {
+  //         id:7,
+  //         name: "Curso 1",
+  //         teacher: "Gustavo Raña",
+  //         image: "https://s31450.pcdn.co/wp-content/uploads/2015/10/iStock_computer-art.151110.jpg"
+  //       },
+  //       {
+  //         id:8,
+  //         name: "Curso 2",
+  //         teacher: "Mateus Vinicius",
+  //         image: "https://ugc.futurelearn.com/uploads/images/41/22/regular_4122fa44-6ac3-4c39-ba9b-29a7160e763b.jpg"
+  //       },
+  //       {
+  //         id:9,
+  //         name: "Curso 3",
+  //         teacher: "Patricia Camarões",
+  //         image: "http://i.imgur.com/SrPdUD4.png"
+  //       },
+  //     ]
+  //   },
+  //   ]
+  // }),
 };
 </script>
 
-<style>
+<style scoped>
 .max-content{
+  max-height: 100vh;
+  padding-bottom: 56px;
+  overflow-y: auto;
   width: 100%;
   max-width: 860px;
   box-sizing: border-box;
   margin: 0 auto;
-  padding-bottom: 80px;
 }
 
 .welcome{

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -53,7 +53,7 @@ export default {
       let storedUser = JSON.parse(localStorage.getItem("user"))
       if (storedUser) {
         this.user = storedUser;
-        this.user.name = this.user.name.split(' ')[0]
+        this.user.name = storedUser.name.split(' ')[0]
       }
     }
   },

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -1,12 +1,12 @@
 <template>
-  <main class="max-content">
+  <main class="max-content" id="page">
     <header class="welcome">
       <h1 class="welcome-title">{{'Olá ' + user.name}}</h1>
       <h2 class="welcome-subtitle">Seja bem vindo</h2>
     </header>
 
-    <article>
-      <h3 class="titleSection">CURSOS</h3>
+    <h3 class="title-section">CURSOS</h3>
+    <article class="article-container">
       <course-card
         :key="course.id"
         v-for="course in courses"
@@ -29,7 +29,7 @@
       </header>
 
       <article :key="category.name" v-for="category in categoryCourses">
-        <h3 class="titleSection">{{category.name}}</h3>
+        <h3 class="title-section">{{category.name}}</h3>
         <horizontal-scroll :horizontalPadding="34" :gap="20">
           <course-card
             v-for="course in category.courses"
@@ -168,18 +168,8 @@ export default {
 </script>
 
 <style scoped>
-.max-content{
-  max-height: 100vh;
-  padding-bottom: 56px;
-  overflow-y: auto;
-  width: 100%;
-  max-width: 860px;
-  box-sizing: border-box;
-  margin: 0 auto;
-}
-
 .welcome{
-  padding: 16px 34px 0;
+  padding: 1em 0 0 1.5em;
 }
 
 .welcome-title{
@@ -197,12 +187,72 @@ export default {
   color: #6600CC;
 }
 
-.titleSection{
+@media screen and (orientation: portrait) {
+  .article-container {
+    flex-flow: column wrap;
+  }
+
+  @media (min-width: 27.5em) {
+    .article-container {
+      flex-flow: row wrap;
+      padding: 0 1em 56px 1.5em;
+    }
+  }
+}
+
+@media screen and (orientation: landscape) {
+  .article-container {
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-content: flex-start;
+    overflow-x: auto;
+    margin: 0 2em 56px 1.5em;
+    padding: 0;
+  }
+
+  @media (min-width: 48em) {
+    .article-container {
+      flex-flow: row wrap;
+      margin: 0;
+    }
+  }
+}
+
+@media (min-width: 48em) {
+  .welcome {
+    padding-top: 2em;
+  }
+
+  .welcome-title {
+    font-size: 2em;
+    line-height: 0.8em;
+  }
+
+  .welcome-subtitle {
+    font-size: 1.3em;
+  }
+}
+
+.article-container {
+  display: flex;
+  max-width: 100vw;
+  padding: 0 2em 56px 1.5em;
+}
+
+.max-content{
+  max-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.title-section{
   font-weight: 900;
-  font-size: 14px;
   line-height: 17px;
   color: #6600CC;
-  padding: 20px 34px 10px;
+  padding: 1.25em 0 0.5em 1.5em;
   text-transform: uppercase;
 }
 

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -86,7 +86,7 @@ export default {
     this.loadUserName();
   },
   asyncData({ store, data, params, $axios }) {
-    const coursesPromise = courses.getAll().then(response =>
+    return courses.getAll().then(response =>
       store.commit('courses/set', response.data)
     )
     return Promise.resolve(coursesPromise)

--- a/pages/student/home.vue
+++ b/pages/student/home.vue
@@ -74,7 +74,7 @@ export default {
     }
   },
   methods: {
-    getUser() {
+    loadUserName() {
       let storedUser = JSON.parse(localStorage.getItem("user"))
       if (storedUser) {
         this.user = storedUser;

--- a/services/http/courses.js
+++ b/services/http/courses.js
@@ -6,6 +6,11 @@ import auth from './auth'
  * Serviço de Cursos
  */
 export default {
+  getAll: () => {
+    const { accessToken } = auth.getInfoAuth()
+    return http.get('/api/v1/course', { headers: { 'Authorization': accessToken}})
+  },
+
   getBySlug: (slug) => {
     const { accessToken } = auth.getInfoAuth()
     return http.get(`api/v1/course/slug/${slug}`, { headers: { 'Authorization': `${accessToken}` } })


### PR DESCRIPTION
Implementando componente home, com nome de usuário e cursos buscados pelo banco. Lista das alterações:

- Listagem de todos os cursos através do endpoint '/api/v1/course';
- Remoção das categorias presentes no layout anterior, mudando para apenas uma tag article na página;
- Scroll quando ultrapassa o limite de altura da tag main;
- Não foi implementado o critério de aceite "AO CLICAR NO CURSO, INICIA O MESMO.", pois ao meu ver ele precisa de um segundo componente ainda não pensado (e até parte no banco, se for relacionar o curso ao usuário autenticado);
- Retirando id duplicada para item do menu (havia 2 itens com id 1);

![2020-01-05-003532_1680x1050_scrot](https://user-images.githubusercontent.com/32306797/71774945-d8403180-2f56-11ea-8bd6-d5e6ae5c5b87.png)
