### PR TITLE
Correçao pagina sobre sem scroll e 404 

### DIFF
--- a/pages/public/quem_somos.vue
+++ b/pages/public/quem_somos.vue
@@ -39,3 +39,8 @@ export default {
   }
 }
 </script>
+<style scoped>
+::v-deep div{
+  overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
bom a correção do 404 foi feito na PR 112, na qual foi adicionada uma rota.
a mesma exibiu um erro de scroll e foi feito agora conforme task:
https://trello.com/c/xpBG1Cms/87-p%C3%A1gina-sobre-com-erro-404