### PR TITLE
Correção na captura do token durante cadastro de usuário (Issue #140)

### DIFF
--- a/pages/public/signup.vue
+++ b/pages/public/signup.vue
@@ -151,20 +151,27 @@ export default {
         const postObject = Object.assign({}, this.form)
         delete postObject.confirmPassword
         this.animateForm(true)
-        auth
-          .signUp(postObject, this.token)
+        this.loadClientCredentials()
           .then(res => {
-            this.loading = false
-            this.confirmSnackbar('Cadastro efetuado! ;)', 'success')
-            setTimeout(() => {
-              this.gotoLogin()
-            }, 2500)
+            this.token = res.data.accessToken
+            auth
+              .signUp(postObject, this.token)
+              .then(res => {
+                this.loading = false
+                this.confirmSnackbar('Cadastro efetuado! ;)', 'success')
+                setTimeout(() => {
+                  this.gotoLogin()
+                }, 2500)
+              })
+              .catch(err => {
+                setTimeout(() => {
+                  this.loading = false
+                }, 500)
+                console.error(err)
+              })
           })
-          .catch(err => {
-            setTimeout(() => {
-              this.loading = false
-            }, 500)
-            console.error(err)
+          .catch(() => {
+            $nuxt._router.push('/login')
           })
       } else {
         this.animateForm(false)
@@ -209,20 +216,8 @@ export default {
       this.snackbar = true
     },
     loadClientCredentials() {
-      utils
-        .getExternalCredentials()
-        .then(res => {
-          console.log(res)
-          this.token = res.data.accessToken
-        })
-        .catch(() => {
-          $nuxt._router.push('/login')
-        })
+      return utils.getExternalCredentials()
     },
-  },
-
-  mounted() {
-    this.loadClientCredentials()
   },
 
   computed: {

--- a/pages/public/signup.vue
+++ b/pages/public/signup.vue
@@ -109,7 +109,6 @@ export default {
       snackbar: false,
       snackbarText: '',
       snackbarStatus: '',
-      token: '',
       form: {
         name: '',
         email: '',
@@ -153,9 +152,9 @@ export default {
         this.animateForm(true)
         this.loadClientCredentials()
           .then(res => {
-            this.token = res.data.accessToken
+            const token = res.data.accessToken
             auth
-              .signUp(postObject, this.token)
+              .signUp(postObject, token)
               .then(res => {
                 this.loading = false
                 this.confirmSnackbar('Cadastro efetuado! ;)', 'success')


### PR DESCRIPTION
Correção da issue #140 aberta pelo Andrews, para fazer a captura do token apenas durante a submissão do form de cadastro do usuário.