### PR TITLE
Resolvi o problema do botão de voltar, sobrepondo o título da página o que é a New School 

### DIFF
--- a/pages/public/about.vue
+++ b/pages/public/about.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <div class="bg"></div>
-    <HeaderBar class="top" :title="'O QUE É A NEW SCHOOL?'" :backPage="true"></HeaderBar>
+    <HeaderBar class="top" :backPage="true"  ></HeaderBar>
+    <header><h1 id="titulo">O QUE É A NEW SCHOOL?</h1></header>
     <div class="container">
       <v-layout text-left>
         <v-flex>
@@ -59,6 +60,17 @@ export default {
   font-family: 'Montserrat';
   text-transform: uppercase;
 }
+h1#titulo {
+  font-size: 14px;
+  color: #6600cc;
+  text-align: center;
+  position: relative;
+  bottom: 30px;
+}
+.top {
+  position: relative;
+  right: 23px;
+}
 ::v-deep .container {
   max-width: 500px;
 }
@@ -90,7 +102,6 @@ p ::v-deep .subtext p {
     text-align: center;
   }
 }
-
 </style>
 
 


### PR DESCRIPTION
O botão de voltar estava sobrepondo o título da pagina, deixei o backPage na área de headerBar, e criei um header em baixo para colocar o título usando h1, assim consegui usar position: relative em ambos, utilizando rigth e bottom e font-size, consegui ajustar a posição deles, para que o erro não acontecesse, e testei em todos os parâmetros de mobile que tem no google chrome.