### PR TITLE
Correção layout dos cards página (contribua)

### DIFF
--- a/pages/public/contribute.vue
+++ b/pages/public/contribute.vue
@@ -153,7 +153,7 @@ export default {
         {
           id: 5,
           cover:
-            'https://www.stickpng.com/assets/images/58482feacef1014c0b5e4a8d.png',
+            'https://cdn.worldvectorlogo.com/logos/rollbar.svg',
           title: 'Rollbar',
           description:
             'Monitoramento e notificação de erros integrado com nossas demais ferramentas.',
@@ -164,7 +164,7 @@ export default {
         {
           id: 6,
           cover:
-            'http://assets.stickpng.com/thumbs/58480873cef1014c0b5e48ea.png',
+            'https://cdn.worldvectorlogo.com/logos/heroku.svg',
           title: 'Heroku',
           description: 'Hospedagem gratuita para os ambientes DEV e STG.',
           linkUrl: 'https://www.heroku.com/',


### PR DESCRIPTION
CARD: https://trello.com/c/GY9gpZGB/32-50-p%C3%A1gina-cola-com-noix-com-layout-quebrado-no-rollbar-e-heroku-contribua

Os logos dos cards "Rollbar" e "Heroku" não estavam carregando, isso estava quebrando o layout da página, as imagens estavam sendo pegas do site "stickpng.com", os links não estavam quebrados, mas por algum motivo desconhecido simplesmente não acessavam se não fosse por navegação direta. Imagino que "stickpng.com" não seja um bom site para se utilizar daqui para frente, achei outro que possui um banco vasto de logos e em formato SVG (worldvectorlogo.com), seria interessante mudar todos os logos dessa página para SVG pois é muito mais leve, não pela página estar lenta, mas pensando no benefício para os usuários que acessarem o app via conexão móvel.