### PR TITLE
Opção de solução para bug de curso completo.

### DIFF
--- a/pages/student/take_course/course.vue
+++ b/pages/student/take_course/course.vue
@@ -24,19 +24,7 @@
               <p id="description">{{ course.description }}</p>
             </div>
             <v-btn
-              v-if="flagButton"
-              class="btn__primary"
-              color="#60c"
-              :loading="loadingInit"
-              :disabled="loadingInit"
-              dark
-              block
-              depressed
-              large
-              @click="initCourse(course.id)"
-            >Iniciar</v-btn>
-            <v-btn
-              v-else
+              v-if="flagButtonTaken"
               class="btn__primary"
               color="#60c"
               :loading="loadingInit"
@@ -47,6 +35,30 @@
               large
               @click="continueCourse(course)"
             >Continuar</v-btn>
+            <v-btn
+              v-else-if="flagButtonCompleted"
+              class="btn__primary"
+              color="#60c"
+              :loading="loadingInit"
+              :disabled="loadingInit"
+              dark
+              block
+              depressed
+              large
+              @click="goToCertificate(course.id)"
+            >Certificado</v-btn>
+            <v-btn
+              v-else
+              class="btn__primary"
+              color="#60c"
+              :loading="loadingInit"
+              :disabled="loadingInit"
+              dark
+              block
+              depressed
+              large
+              @click="initCourse(course.id)"
+            >Iniciar</v-btn>
           </main>
         </div>
         <modal
@@ -92,8 +104,9 @@ export default {
       loadingInit: false,
       loading: true,
       notFound: false,
-      flagButton: true,
       course: {},
+      flagButtonTaken: false,
+      flagButtonCompleted: false,
     };
   },
   mounted() {
@@ -214,6 +227,12 @@ export default {
               }
             });
         });
+    },
+    goToCertificate(id) {
+      // eslint-disable-next-line no-undef
+      $nuxt._router.push(
+        `/pagina-certificado/${this.$store.state.user.data.id}/${id}`,
+      );
     },
   },
   computed: {


### PR DESCRIPTION
Essa é uma opção diferente para a solução do bug ao tentar iniciar um curso já completo.
Minha PR com solução antiga: https://github.com/NewSchoolApp/newschool-frontend/pull/248
Card: https://trello.com/c/yZkmoyKp/27-50-quando-um-curso-j%C3%A1-foi-finalizado-ao-iniciar-retorna-o-erro-this-course-already-started-for-this-user

Fiz essa solução mais prática onde o aluno encontra um botão de "Certificado" na tela de um curso que já completou, assim já o direcionando para o certificado referente.