### PR TITLE
Correção ícones social sharing

### DIFF
--- a/pages/public/certificate_info.vue
+++ b/pages/public/certificate_info.vue
@@ -43,13 +43,13 @@
       >
         <div class="box-icons">
           <network class="icon" network="facebook">
-            <v-icon color="purple darken-2"> mdi-facebook </v-icon>
+            <img src="~/assets/facebook-purple.png" alt />
           </network>
           <network class="icon" network="twitter">
-            <v-icon color="purple darken-2"> mdi-twitter </v-icon>
+            <img src="~/assets/twitter-purple.png" alt />
           </network>
           <network class="icon" network="linkedin">
-            <v-icon color="purple darken-2"> mdi-linkedin </v-icon>
+            <img src="~/assets/linkedin-purple.png" alt />
           </network>
         </div>
       </social-sharing>


### PR DESCRIPTION
Foi necessário trocar o uso do "v-icon" utilizado para renderizar o ícone dos botões de compartilhar certificado para imagens comuns, a extensão "vue-social-sharing" utilizada pelo projeto para realizar o compartilhamento de conteúdo em redes sociais não aceita receber uma tag "v-icon" em seus botões.