### PR TITLE
ajuste do erro na tela de certificado trocando o nome do autor pelo do usuario

### DIFF
--- a/components/CertificateCard.vue
+++ b/components/CertificateCard.vue
@@ -17,9 +17,9 @@
     </div>
     <div class="footer">
       <div class="title-and-socialMedias">
-        <button type="button" @click="goToCertificate(certificate.course.id)">
+        <button  type="button" @click="goToCertificate(certificate.course.id)" >
           <p class="certificate-title">{{ certificate.course.title }}</p>
-          <p>{{ certificate.user.name }}</p>
+          <p>{{certificate.course.authorName }}</p>
         </button>
       </div>
     </div>


### PR DESCRIPTION
Arrumei o erro da tela de certificado aonde mostrava o nome do usuário ao invés do nome do autor do curso.
Link trello: https://trello.com/c/3KqAZ5iz